### PR TITLE
docs: outline PWA spec using AIAW lite with MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # AI_APP
+
 AI APP customization
+
+## Specification
+
+This repository hosts a Progressive Web App built with the **AIAW AI client (lite version)** that communicates with two MCP servers. Hosting the app on GitHub allows users to run it as a PWA directly on their mobile devices.
+
+### Features
+- **AIAW AI client - lite version** to keep the bundle minimal.
+- Connects to two MCP servers:
+  - `MCP_SERVER_A`
+  - `MCP_SERVER_B`
+- Packaged as a Progressive Web App so users can install it to their home screen and run offline.
+
+### Usage
+1. Clone this repository.
+2. Configure the endpoints for both MCP servers in the client configuration.
+3. Deploy the app to GitHub Pages.
+4. From a mobile device, open the GitHub Pages URL and choose "Add to Home Screen" to install the PWA.
+
+### Deployment Tips
+- Enable GitHub Pages for this repository.
+- Each push to the repository updates the PWA build, ensuring users always have the latest version.


### PR DESCRIPTION
## Summary
- document using the AIAW AI client (lite version)
- describe integration with two MCP servers
- note PWA deployment via GitHub for mobile use

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eaaf9a994832fac06afcea326347d