### PR TITLE
docs: document websocketd MCP server integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # AI_APP
+
 AI APP customization
+
+## Specification
+
+This repository hosts a Progressive Web App built with the **AIAW AI client (lite version)** that communicates with two MCP servers. Hosting the app on GitHub allows users to run it as a PWA directly on their mobile devices.
+
+### Features
+- **AIAW AI client - lite version** to keep the bundle minimal.
+- Connects to two MCP servers:
+  - `MCP_SERVER_A`
+  - `MCP_SERVER_B`
+- Packaged as a Progressive Web App so users can install it to their home screen and run offline.
+- Utilizes a JavaScript-based MCP server exposed through `websocketd` for WebSocket communication. GitHub remains the primary repository and deployment target (final hosting details TBD).
+
+### Usage
+1. Clone this repository.
+2. Configure the endpoints for both MCP servers in the client configuration.
+3. Run `websocketd` to expose the JavaScript MCP server for real-time communication.
+4. Deploy the app to GitHub Pages.
+5. From a mobile device, open the GitHub Pages URL and choose "Add to Home Screen" to install the PWA.
+
+### Deployment Tips
+- Enable GitHub Pages for this repository.
+- Each push to the repository updates the PWA build, ensuring users always have the latest version.


### PR DESCRIPTION
## Summary
- describe using a JavaScript MCP server exposed via `websocketd`
- outline setup steps for running `websocketd` before deploying to GitHub Pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eaaf9a994832fac06afcea326347d